### PR TITLE
Fix scripts for demo fib

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "main": "index.js",
   "scripts": {
     "test": "mocha",
-    "fibonacci_buidconst": "node test/sm_fibonacci/main_genconst_fibonacci.js -o tmp/fibonacci.const.bin",
+    "fibonacci_buidconst": "node test/sm_fibonacci/main_buildconst_fibonacci.js -o tmp/fibonacci.const.bin",
     "fibonacci_exec": "node test/sm_fibonacci/main_exec_fibonacci.js -i test/sm_fibonacci/fibonacci.input.json -o tmp/fibonacci.commit.bin",
-    "fibonacci_buildconsttree": "node src/main_buildconsttree.js -c tmp/fibonacci.const.bin -p test/sm_fibonacci/fibonacci.pil -s tmp/fibonacci.starkstruct.json -t tmp/fibonacci.consttree.bin -v tmp/fibonacci.verkey.json",
+    "fibonacci_buildconsttree": "node src/main_buildconsttree.js -c tmp/fibonacci.const.bin -p test/sm_fibonacci/fibonacci_main.pil -s ./test/sm_fibonacci/fibonacci.starkstruct.json -t tmp/fibonacci.consttree.bin -v tmp/fibonacci.verkey.json",
     "fibonacci_compileverifier": "circom -l circuits.gl --O1 --prime goldilocks --r1cs --sym --wasm --verbose tmp/fibonacci.verifier.circom -o tmp",
     "fibonacci_compileC12verifier": "circom -l circuits.bn128 -l node_modules/circomlib/circuits --O1 --r1cs --sym --wasm --verbose tmp/fibonacci.c12.verifier.circom -o tmp",
     "all_compileverifier": "circom -l circuits.gl  --O1 --prime goldilocks --r1cs --sym --wasm --c --verbose tmp/all.verifier.circom -o tmp",


### PR DESCRIPTION
When I run the demo to generate Stark verifier by running fibonacci_buidconst,  fibonacci_exec,  main_pilverifier, fibonacci_buildconsttree, main_prover, main_pil2circom to generate fibonacci.verifier.circom, found some errors for existing command in package.json. 