### PR TITLE
Fix import buildMerklehashBN128

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "main": "index.js",
   "scripts": {
     "test": "mocha",
-    "fibonacci_buidconst": "node test/sm_fibonacci/main_genconst_fibonacci.js -o tmp/fibonacci.const.bin",
+    "fibonacci_buidconst": "node test/sm_fibonacci/main_buildconst_fibonacci.js -o tmp/fibonacci.const.bin",
     "fibonacci_exec": "node test/sm_fibonacci/main_exec_fibonacci.js -i test/sm_fibonacci/fibonacci.input.json -o tmp/fibonacci.commit.bin",
-    "fibonacci_buildconsttree": "node src/main_buildconsttree.js -c tmp/fibonacci.const.bin -p test/sm_fibonacci/fibonacci.pil -s tmp/fibonacci.starkstruct.json -t tmp/fibonacci.consttree.bin -v tmp/fibonacci.verkey.json",
+    "fibonacci_buildconsttree": "node src/main_buildconsttree.js -c tmp/fibonacci.const.bin -p test/sm_fibonacci/fibonacci_main.pil -s ./test/sm_fibonacci/fibonacci.starkstruct.json -t tmp/fibonacci.consttree.bin -v tmp/fibonacci.verkey.json",
     "fibonacci_compileverifier": "circom -l circuits.gl --O1 --prime goldilocks --r1cs --sym --wasm --verbose tmp/fibonacci.verifier.circom -o tmp",
     "fibonacci_compileC12verifier": "circom -l circuits.bn128 -l node_modules/circomlib/circuits --O1 --r1cs --sym --wasm --verbose tmp/fibonacci.c12.verifier.circom -o tmp",
     "all_compileverifier": "circom -l circuits.gl  --O1 --prime goldilocks --r1cs --sym --wasm --c --verbose tmp/all.verifier.circom -o tmp",

--- a/src/stark_setup.js
+++ b/src/stark_setup.js
@@ -1,7 +1,7 @@
 
 const {BigBuffer} = require("pilcom");
 const buildMerklehashGL = require("../src/merklehash_p.js");
-const buildMerklehashBN128 = require("../src/merklehash.bn128.js");
+const buildMerklehashBN128 = require("../src/merklehash_bn128_p.js");
 const starkInfoGen = require("../src/starkinfo.js")
 
 const { interpolate } = require("../src/fft_p");


### PR DESCRIPTION
Fix:
1. some invalid directories in `package.json`
2. invalid import buildMerklehashBN128 in stark_setup.js
3. confusing:  literally, we can use no custom gate expression in pil program, so the assert can be removed [here](https://github.com/0xPolygonHermez/pil-stark/blob/main/src/compressor12/compressor12_setup.js#L260) ? 

@jbaylina Can you please have a look?  thanks!