### PR TITLE
small fixes to version 0.0.50

### DIFF
--- a/circuits.bn128/merklehash.circom
+++ b/circuits.bn128/merklehash.circom
@@ -5,13 +5,31 @@ include "merkle.circom";
 include "utils.circom";
 
 /*
-    Given a leaf value and its sibling path, calculate the merkle tree root and check that it matches with the one provided
+    Given a leaf value and its sibling path, calculate the merkle tree root 
     - eSize: Size of the extended field (usually it will be either 3 if we are in Fp³ or 1)
     - elementsInLinear: Each leave of the merkle tree is made by this number of values. 
     - nLinears: Number of leaves of the merkle tree
 */
+template parallel MerkleHash(eSize, elementsInLinear, nLinears) {
+    var nBits = log2(nLinears);
+    assert(1 << nBits == nLinears);
+    var nLevels = (nBits - 1)\4 +1;
+    signal input values[elementsInLinear][eSize];
+    signal input siblings[nLevels][16]; // Sibling path to calculate the merkle root given a set of values. Why 16 ???
+    signal input key[nBits]; // Defines either each element of the sibling path is the left or right one
+    signal output root; // Root of the merkle tree
+
+    // Each leaf in the merkle tree might be composed by multiple values. Therefore, the first step is to 
+    // reduce all those values into a single one by hashing all of them
+    signal linearHash <== LinearHash(elementsInLinear, eSize)(values);
+
+    // Calculate the merkle root 
+    root <== Merkle(nBits)(linearHash, siblings ,key);
+}
+
+
 template parallel VerifyMerkleHash(eSize, elementsInLinear, nLinears) {
-    var nBits = log2(nLinears); 
+    var nBits = log2(nLinears);
     assert(1 << nBits == nLinears);
     var nLevels = (nBits - 1)\4 +1;
     signal input values[elementsInLinear][eSize];
@@ -20,13 +38,10 @@ template parallel VerifyMerkleHash(eSize, elementsInLinear, nLinears) {
     signal input root; // Root of the merkle tree
     signal input enable; // Boolean that determines either we want to check that roots matches or not
 
-    // Each leaf in the merkle tree might be composed by multiple values. Therefore, the first step is to 
-    // reduce all those values into a single one by hashing all of them
-    signal linearHash <== LinearHash(elementsInLinear, eSize)(values);
-  
     // Calculate the merkle root 
-    signal merkleRoot <== Merkle(nBits)(linearHash, siblings, key);
+    signal merkleRoot <== MerkleHash(eSize, elementsInLinear, nLinears)(values, siblings, key);
 
     // If enable is set to 1, check that the merkleRoot being calculated matches with the one sent as input
     enable * (merkleRoot - root) === 0;
 }
+

--- a/circuits.bn128/stark_verifier.circom.ejs
+++ b/circuits.bn128/stark_verifier.circom.ejs
@@ -180,77 +180,75 @@ class Transcript {
         }
     }
 -%>
-<% var tmpNameId = 0;                                                                   -%>
 <% for(let i=0; i<code.length; i++) {                                 -%>
 <%      let inst = code[i];                                           -%>
-<%      let outputName;                                           -%>
-<%      if (inst.dest.type == "tmp") {                                                  -%>
-<%          if (inst.dest.dim == 1) {                                                   -%>
-<%              outputName = `signal ${ref(inst.dest)}`                                                -%>
-<%          } else if (inst.dest.dim == 3)  {                                           -%>
-<%              outputName = `signal ${ref(inst.dest)}[3]`                                                -%>
-<%          } else throw new Error("Invalid dimension");                                -%>
+<%      if (inst.dest.type == "tmp" && ![1,3].includes(inst.dest.dim)) {                -%>
+<%          throw new Error("Invalid dimension");                                       -%>
 <%      }                                                                               -%>
 <%      if (inst.op == "add") {                                                         -%>
 <%          if ((inst.src[0].dim==1) && (inst.src[1].dim==1)) {                         -%>
-    <%- outputName %> <== <%- ref(inst.src[0]) %> + <%- ref(inst.src[1]) %>;
+    signal <%- ref(inst.dest) %> <== <%- ref(inst.src[0]) %> + <%- ref(inst.src[1]) %>;
 <%          } else if ((inst.src[0].dim==1) && (inst.src[1].dim==3)) {                  -%>
-    <%- outputName %> <== [<%- ref(inst.src[0]) %> + <%- ref(inst.src[1]) %>[0], <%- ref(inst.src[1]) %>[1],<%- ref(inst.src[1]) %>[2]] ;
+    signal <%- ref(inst.dest) %>[3] <== [<%- ref(inst.src[0]) %> + <%- ref(inst.src[1]) %>[0], <%- ref(inst.src[1]) %>[1], <%- ref(inst.src[1]) %>[2]];
 <%          } else if ((inst.src[0].dim==3) && (inst.src[1].dim==1)) {                  -%>
-    <%- outputName %> <== [<%- ref(inst.src[0]) %>[0] + <%- ref(inst.src[1]) %>, <%- ref(inst.src[0]) %>[1], <%- ref(inst.src[0]) %>[2]];
+    signal <%- ref(inst.dest) %>[3] <== [<%- ref(inst.src[0]) %>[0] + <%- ref(inst.src[1]) %>, <%- ref(inst.src[0]) %>[1], <%- ref(inst.src[0]) %>[2]];
 <%          } else if ((inst.src[0].dim==3) && (inst.src[1].dim==3)) {                  -%>
-    <%- outputName %> <== [<%- ref(inst.src[0]) %>[0] + <%- ref(inst.src[1]) %>[0], <%- ref(inst.src[0]) %>[1] + <%- ref(inst.src[1]) %>[1], <%- ref(inst.src[0]) %>[2] + <%- ref(inst.src[1]) %>[2]];
+    signal <%- ref(inst.dest) %>[3] <== [<%- ref(inst.src[0]) %>[0] + <%- ref(inst.src[1]) %>[0], <%- ref(inst.src[0]) %>[1] + <%- ref(inst.src[1]) %>[1], <%- ref(inst.src[0]) %>[2] + <%- ref(inst.src[1]) %>[2]];
 <%          } else throw new Error("Invalid src dimensions");                          -%>
 <%      } else if (inst.op == "sub") {                                                  -%>
 <%          if ((inst.src[0].dim==1) && (inst.src[1].dim==1)) {                         -%>
-    <%- outputName %> <== <%- ref(inst.src[0]) %> - <%- ref(inst.src[1]) %>;
+    signal <%- ref(inst.dest) %> <== <%- ref(inst.src[0]) %> - <%- ref(inst.src[1]) %>;
 <%          } else if ((inst.src[0].dim==1) && (inst.src[1].dim==3)) {                  -%>
-    <%- outputName %> <== [<%- ref(inst.src[0]) %> - <%- ref(inst.src[1]) %>[0], -<%- ref(inst.src[1]) %>[1], -<%- ref(inst.src[1]) %>[2]];
+    signal <%- ref(inst.dest) %>[3] <== [<%- ref(inst.src[0]) %> - <%- ref(inst.src[1]) %>[0] + p, -<%- ref(inst.src[1]) %>[1] + p, -<%- ref(inst.src[1]) %>[2] + p];
 <%          } else if ((inst.src[0].dim==3) && (inst.src[1].dim==1)) {                  -%>
-    <%- outputName %> <== [<%- ref(inst.src[0]) %>[0] - <%- ref(inst.src[1]) %>,  <%- ref(inst.src[0]) %>[1], <%- ref(inst.src[0]) %>[2]];
+    signal <%- ref(inst.dest) %>[3] <== [<%- ref(inst.src[0]) %>[0] - <%- ref(inst.src[1]) %> + p, <%- ref(inst.src[0]) %>[1], <%- ref(inst.src[0]) %>[2]];
 <%          } else if ((inst.src[0].dim==3) && (inst.src[1].dim==3)) {                  -%>
-    <%- outputName %> <== [<%- ref(inst.src[0]) %>[0] - <%- ref(inst.src[1]) %>[0],  <%- ref(inst.src[0]) %>[1] - <%- ref(inst.src[1]) %>[1],<%- ref(inst.src[0]) %>[2] - <%- ref(inst.src[1]) %>[2]];
+    signal <%- ref(inst.dest) %>[3] <== [<%- ref(inst.src[0]) %>[0] - <%- ref(inst.src[1]) %>[0] + p, <%- ref(inst.src[0]) %>[1] - <%- ref(inst.src[1]) %>[1] + p, <%- ref(inst.src[0]) %>[2] - <%- ref(inst.src[1]) %>[2] + p];
 <%          } else throw new Error("Invalid src dimensions");                          -%>
 <%      } else if (inst.op == "mul") {                                                  -%>
 <%          if ((inst.src[0].dim==1) && (inst.src[1].dim==1)) {                         -%>
-    <%- outputName %> <== GLMul1()(<%- ref(inst.src[0]) %>, <%- ref(inst.src[1]) %>);
+    signal <%- ref(inst.dest) %> <== GLMul1()(<%- ref(inst.src[0]) %>, <%- ref(inst.src[1]) %>);
 <%          } else if ((inst.src[0].dim==1) && (inst.src[1].dim==3)) {                  -%>
-    <%- outputName %> <== GLCMul()([<%- ref(inst.src[0]) %>, 0, 0], <%- ref(inst.src[1]) %>);
+    signal <%- ref(inst.dest) %>[3] <== GLCMul()([<%- ref(inst.src[0]) %>, 0, 0], <%- ref(inst.src[1]) %>);
 <%          } else if ((inst.src[0].dim==3) && (inst.src[1].dim==1)) {                  -%>
-    <%- outputName %> <== GLCMul()(<%- ref(inst.src[0]) %>,[<%- ref(inst.src[1]) %>, 0, 0]);
+    signal <%- ref(inst.dest) %>[3] <== GLCMul()(<%- ref(inst.src[0]) %>, [<%- ref(inst.src[1]) %>,0,0]);
 <%          } else if ((inst.src[0].dim==3) && (inst.src[1].dim==3)) {                  -%>
-    <%- outputName %> <== GLCMul()(<%- ref(inst.src[0]) %>,<%- ref(inst.src[1]) %>);
+    signal <%- ref(inst.dest) %>[3] <== GLCMul()(<%- ref(inst.src[0]) %>, <%- ref(inst.src[1]) %>);
 <%          } else throw new Error("Invalid src dimensions");                          -%>
 <%      } else if (inst.op == "copy") {                                                 -%>
-<%          if (inst.src[0].dim==1 || inst.src[0].dim==3) {                                                   -%>
-    <%- outputName %> <== <%- ref(inst.src[0]) %>;
+<%          if (inst.src[0].dim==1) {                                                   -%>
+    signal <%- ref(inst.dest) %> <== <%- ref(inst.src[0]) %>;
+<%          } else if (inst.src[0].dim==3) {                                            -%>
+    signal <%- ref(inst.dest) %>[3] <== <%- ref(inst.src[0]) %>;
 <%          } else throw new Error("Invalid src dimensions");                          -%>
 <%      } else if (inst.op == "muladd") {                                                   -%>
 <%              if ((inst.src[0].dim==1) && (inst.src[1].dim==1)) {                         -%>
 <%                  if (inst.src[2].dim==1) {                                                -%>
-    <%- outputName %> <== GLMulAdd()(<%- ref(inst.src[0]) %>, <%- ref(inst.src[1]) %>, <%- ref(inst.src[2]) %>);
+    signal <%- ref(inst.dest) %> <== GLMulAdd()(<%- ref(inst.src[0]) %>, <%- ref(inst.src[1]) %>, <%- ref(inst.src[2]) %>);
 <%                  } else {                                                                 -%>
-    <%- outputName %> <== [GLMulAdd()(<%- ref(inst.src[0]) %>, <%- ref(inst.src[1]) %>, <%- ref(inst.src[2]) %>[0], <%- ref(inst.src[2]) %>[1], <%- ref(inst.src[2]) %>[2]);
-<%                  }                                                                        -%>
-<%              } else if(inst.src[0].dim==1 && inst.src[1].dim== 3) {   -%>
-<%                  if (inst.src[2].dim==1) {                                                -%>
-    <%- outputName %> <== GLCMulAdd()([<%- ref(inst.src[0]) %>, 0, 0], <%- ref(inst.src[1]) %>, [<%- ref(inst.src[2]) %>, 0, 0]);
-<%                  } else {                                                                 -%>
-    <%- outputName %> <== GLCMulAdd()([<%- ref(inst.src[0]) %>, 0, 0], <%- ref(inst.src[1]) %>, <%- ref(inst.src[2]) %>);
-<%                  }                                                                        -%>
-<%              } else if(inst.src[0].dim==3 && inst.src[1].dim== 1) {   -%>
-<%                  if (inst.src[2].dim==1) {                                                -%>
-    <%- outputName %> <== GLCMulAdd()(<%- ref(inst.src[0]) %>, [<%- ref(inst.src[1]) %>, 0, 0], [<%- ref(inst.src[2]) %>, 0, 0]);
-<%                  } else {                                                                 -%>
-    <%- outputName %> <== GLCMulAdd()(<%- ref(inst.src[0]) %>, [<%- ref(inst.src[1]) %>, 0, 0], <%- ref(inst.src[2]) %>);
-<%                  }                                                                        -%>
-<%              } else if(inst.src[0].dim==3 && inst.src[1].dim== 3) {   -%>
-<%                  if (inst.src[2].dim==1) {                                                -%>
-    <%- outputName %> <== GLCMulAdd()(<%- ref(inst.src[0]) %>, <%- ref(inst.src[1]) %>, [<%- ref(inst.src[2]) %>, 0, 0]);     
-<%                  } else {                                                                 -%>
-    <%- outputName %> <== GLCMulAdd()(<%- ref(inst.src[0]) %>, <%- ref(inst.src[1]) %>, <%- ref(inst.src[2]) %>);
-<%                  }                                                                        -%>
-<%              } else throw new Error("Invalid src dimensions");                           -%>
+    signal <%- ref(inst.dest) %>[3] <== [GLMulAdd()(<%- ref(inst.src[0]) %>, <%- ref(inst.src[1]) %>, <%- ref(inst.src[2]) %>[0]),<%- ref(inst.src[2]) %>[1],<%- ref(inst.src[2]) %>[2]];
+<%                  }                                                                       -%>
+<%              } else {                                                                    -%>
+<%                  let ina;
+                    let inb;
+                    let inc; 
+                    if(inst.src[0].dim==1) {
+                        ina = `[${ref(inst.src[0])},0,0]`;
+                    } else {
+                        ina = `${ref(inst.src[0])}`;
+                    }
+                    if(inst.src[1].dim==1) {
+                        inb = `[${ref(inst.src[1])},0,0]`;
+                    } else {
+                        inb = `${ref(inst.src[1])}`;
+                    }
+                    if(inst.src[2].dim==1) {
+                        inc = `[${ref(inst.src[2])},0,0]`;
+                    } else {
+                        inc = `${ref(inst.src[2])}`;
+                    } -%>
+    signal <%- ref(inst.dest) %>[3] <== GLCMulAdd()(<%- ina %>, <%- inb %>, <%- inc %>);
+<%              }                                                                           -%>
 <%      } else throw new Error("Invalid op");                                           -%>
 <% }                                                                                    -%>
 <% return ref(code[code.length-1].dest);                                                -%>

--- a/circuits.gl/iszero.circom
+++ b/circuits.gl/iszero.circom
@@ -1,0 +1,16 @@
+pragma circom 2.1.0;
+
+/*
+    Check if a value is zero or not. Used in recursive2
+*/
+template IsZero() {
+    signal input in;
+    signal output out;
+
+    signal inv;
+
+    inv <-- in!=0 ? 1/in : 0;
+
+    out <== -in*inv +1;
+    in*out === 0;
+}

--- a/circuits.gl/mux1.circom
+++ b/circuits.gl/mux1.circom
@@ -1,0 +1,16 @@
+pragma circom 2.1.0;
+
+/*
+    Multiplexor used in recursive2
+*/
+template MultiMux1(n) { 
+    signal input c[2][n];  // Constants
+    signal input s;   // Selector
+    signal output out[n];
+
+    for (var i=0; i<n; i++) {
+
+        out[i] <== (c[1][i] - c[0][i])*s + c[0][i];
+
+    }
+}

--- a/circuits.gl/stark_verifier.circom.ejs
+++ b/circuits.gl/stark_verifier.circom.ejs
@@ -159,74 +159,82 @@ class Transcript {
         }
     }
 -%>
-<% var tmpNameId = 0;                                                                   -%>
 <% for(let i=0; i<code.length; i++) {                                 -%>
 <%      let inst = code[i];                                           -%>
-<%      let outputName;                                           -%>
-<%      if (inst.dest.type == "tmp") {                                                  -%>
-<%          if (inst.dest.dim == 1) {                                                   -%>
-<%              outputName = `signal ${ref(inst.dest)}`                                                -%>
-<%          } else if (inst.dest.dim == 3)  {                                           -%>
-<%              outputName = `signal ${ref(inst.dest)}[3]`                                                -%>
-<%          } else throw new Error("Invalid dimension");                                -%>
+<%      if (inst.dest.type == "tmp" && ![1,3].includes(inst.dest.dim)) {                -%>
+<%          throw new Error("Invalid dimension");                                       -%>
 <%      }                                                                               -%>
 <%      if (inst.op == "add") {                                                         -%>
 <%          if ((inst.src[0].dim==1) && (inst.src[1].dim==1)) {                         -%>
-    <%- outputName %> <== <%- ref(inst.src[0]) %> + <%- ref(inst.src[1]) %>;
+    signal <%- ref(inst.dest) %> <== <%- ref(inst.src[0]) %> + <%- ref(inst.src[1]) %>;
 <%          } else if ((inst.src[0].dim==1) && (inst.src[1].dim==3)) {                  -%>
-    <%- outputName %> <== [<%- ref(inst.src[0]) %> + <%- ref(inst.src[1]) %>[0], <%- ref(inst.src[1]) %>[1],<%- ref(inst.src[1]) %>[2]] ;
+    signal <%- ref(inst.dest) %>[3] <== [<%- ref(inst.src[0]) %> + <%- ref(inst.src[1]) %>[0], <%- ref(inst.src[1]) %>[1],  <%- ref(inst.src[1]) %>[2]];
 <%          } else if ((inst.src[0].dim==3) && (inst.src[1].dim==1)) {                  -%>
-    <%- outputName %> <== [<%- ref(inst.src[0]) %>[0] + <%- ref(inst.src[1]) %>, <%- ref(inst.src[0]) %>[1], <%- ref(inst.src[0]) %>[2]];
+    signal <%- ref(inst.dest) %>[3] <== [<%- ref(inst.src[0]) %>[0] + <%- ref(inst.src[1]) %>, <%- ref(inst.src[0]) %>[1], <%- ref(inst.src[0]) %>[2]];
 <%          } else if ((inst.src[0].dim==3) && (inst.src[1].dim==3)) {                  -%>
-    <%- outputName %> <== [<%- ref(inst.src[0]) %>[0] + <%- ref(inst.src[1]) %>[0], <%- ref(inst.src[0]) %>[1] + <%- ref(inst.src[1]) %>[1], <%- ref(inst.src[0]) %>[2] + <%- ref(inst.src[1]) %>[2]];
+    signal <%- ref(inst.dest) %>[3] <== [<%- ref(inst.src[0]) %>[0] + <%- ref(inst.src[1]) %>[0], <%- ref(inst.src[0]) %>[1] + <%- ref(inst.src[1]) %>[1], <%- ref(inst.src[0]) %>[2] + <%- ref(inst.src[1]) %>[2]];
 <%          } else throw new Error("Invalid src dimensions");                          -%>
 <%      } else if (inst.op == "sub") {                                                  -%>
 <%          if ((inst.src[0].dim==1) && (inst.src[1].dim==1)) {                         -%>
-    <%- outputName %> <== <%- ref(inst.src[0]) %> - <%- ref(inst.src[1]) %>;
+    signal <%- ref(inst.dest) %> <== <%- ref(inst.src[0]) %> - <%- ref(inst.src[1]) %>;
 <%          } else if ((inst.src[0].dim==1) && (inst.src[1].dim==3)) {                  -%>
-    <%- outputName %> <== [<%- ref(inst.src[0]) %> - <%- ref(inst.src[1]) %>[0], -<%- ref(inst.src[1]) %>[1], -<%- ref(inst.src[1]) %>[2]];
+    signal <%- ref(inst.dest) %>[3] <== [<%- ref(inst.src[0]) %> - <%- ref(inst.src[1]) %>[0], -<%- ref(inst.src[1]) %>[1], -<%- ref(inst.src[1]) %>[2]];
 <%          } else if ((inst.src[0].dim==3) && (inst.src[1].dim==1)) {                  -%>
-    <%- outputName %> <== [<%- ref(inst.src[0]) %>[0] - <%- ref(inst.src[1]) %>,  <%- ref(inst.src[0]) %>[1], <%- ref(inst.src[0]) %>[2]];
+    signal <%- ref(inst.dest) %>[3] <== [<%- ref(inst.src[0]) %>[0] - <%- ref(inst.src[1]) %>, <%- ref(inst.src[0]) %>[1], <%- ref(inst.src[0]) %>[2]];
 <%          } else if ((inst.src[0].dim==3) && (inst.src[1].dim==3)) {                  -%>
-    <%- outputName %> <== [<%- ref(inst.src[0]) %>[0] - <%- ref(inst.src[1]) %>[0],  <%- ref(inst.src[0]) %>[1] - <%- ref(inst.src[1]) %>[1],<%- ref(inst.src[0]) %>[2] - <%- ref(inst.src[1]) %>[2]];
+    signal <%- ref(inst.dest) %>[3] <== [<%- ref(inst.src[0]) %>[0] - <%- ref(inst.src[1]) %>[0], <%- ref(inst.src[0]) %>[1] - <%- ref(inst.src[1]) %>[1], <%- ref(inst.src[0]) %>[2] - <%- ref(inst.src[1]) %>[2]];
 <%          } else throw new Error("Invalid src dimensions");                          -%>
 <%      } else if (inst.op == "mul") {                                                  -%>
 <%          if ((inst.src[0].dim==1) && (inst.src[1].dim==1)) {                         -%>
-    <%- outputName %> <== <%- ref(inst.src[0]) %> * <%- ref(inst.src[1]) %>;
+    signal <%- ref(inst.dest) %> <== <%- ref(inst.src[0]) %> * <%- ref(inst.src[1]) %>;
 <%          } else if ((inst.src[0].dim==1) && (inst.src[1].dim==3)) {                  -%>
-    <%- outputName %> <== [<%- ref(inst.src[0]) %> * <%- ref(inst.src[1]) %>[0],<%- ref(inst.src[0]) %> * <%- ref(inst.src[1]) %>[1],<%- ref(inst.src[0]) %> * <%- ref(inst.src[1]) %>[2]];
+    signal <%- ref(inst.dest) %>[3] <== [<%- ref(inst.src[0]) %> * <%- ref(inst.src[1]) %>[0], <%- ref(inst.src[0]) %> * <%- ref(inst.src[1]) %>[1], <%- ref(inst.src[0]) %> * <%- ref(inst.src[1]) %>[2]];
 <%          } else if ((inst.src[0].dim==3) && (inst.src[1].dim==1)) {                  -%>
-    <%- outputName %> <== [<%- ref(inst.src[0]) %>[0] * <%- ref(inst.src[1]) %>,  <%- ref(inst.src[0]) %>[1] * <%- ref(inst.src[1]) %>, <%- ref(inst.src[0]) %>[2] * <%- ref(inst.src[1]) %>];
+    signal <%- ref(inst.dest) %>[3] <== [<%- ref(inst.src[0]) %>[0] * <%- ref(inst.src[1]) %>, <%- ref(inst.src[0]) %>[1] * <%- ref(inst.src[1]) %>, <%- ref(inst.src[0]) %>[2] * <%- ref(inst.src[1]) %>];
 <%          } else if ((inst.src[0].dim==3) && (inst.src[1].dim==3)) {                  -%>
-    <%- outputName %> <== CMul()(<%- ref(inst.src[0]) %>, <%- ref(inst.src[1]) %>);
+    signal <%- ref(inst.dest) %>[3] <== CMul()(<%- ref(inst.src[0]) %>, <%- ref(inst.src[1]) %>);
 <%          } else throw new Error("Invalid src dimensions");                              -%>
 <%      } else if (inst.op == "muladd") {                                                   -%>
 <%          if (inst.src[2].dim==1) {                                                      -%>
 <%              if ((inst.src[0].dim==1) && (inst.src[1].dim==1)) {                         -%>
-    <%- outputName %> <== <%- ref(inst.src[0]) %> * <%- ref(inst.src[1]) %> +  <%- ref(inst.src[2]) %>;
+    signal <%- ref(inst.dest) %> <== <%- ref(inst.src[0]) %> * <%- ref(inst.src[1]) %> +  <%- ref(inst.src[2]) %>;
 <%              } else if ((inst.src[0].dim==1) && (inst.src[1].dim==3)) {                  -%>
-    <%- outputName %> <== [<%- ref(inst.src[0]) %> * <%- ref(inst.src[1]) %>[0] +  <%- ref(inst.src[2]) %>, <%- ref(inst.src[0]) %> * <%- ref(inst.src[1]) %>[1], <%- ref(inst.src[0]) %> * <%- ref(inst.src[1]) %>[2]];
+    signal <%- ref(inst.dest) %>[3] <== [<%- ref(inst.src[0]) %> * <%- ref(inst.src[1]) %>[0] +  <%- ref(inst.src[2]) %>,<%- ref(inst.src[0]) %> * <%- ref(inst.src[1]) %>[1], <%- ref(inst.src[0]) %> * <%- ref(inst.src[1]) %>[2]];
 <%              } else if ((inst.src[0].dim==3) && (inst.src[1].dim==1)) {                  -%>
-    <%- outputName %> <== [<%- ref(inst.src[0]) %>[0] * <%- ref(inst.src[1]) %> +  <%- ref(inst.src[2]) %>, <%- ref(inst.src[0]) %>[1] * <%- ref(inst.src[1]) %>,<%- ref(inst.src[0]) %>[2] * <%- ref(inst.src[1]) %> ];
+    signal <%- ref(inst.dest) %>[3] <== [<%- ref(inst.src[0]) %>[0] * <%- ref(inst.src[1]) %> +  <%- ref(inst.src[2]) %>, <%- ref(inst.src[0]) %>[1] * <%- ref(inst.src[1]) %>, <%- ref(inst.src[0]) %>[2] * <%- ref(inst.src[1]) %>];
 <%              } else if ((inst.src[0].dim==3) && (inst.src[1].dim==3)) {                  -%>
-    <%- outputName %> <== CMulAdd()(<%- ref(inst.src[0]) %>, <%- ref(inst.src[1]) %>, [<%- ref(inst.src[2]) %>, 0,0]);
+    signal <%- ref(inst.dest) %>[3] <== CMulAdd()(<%- ref(inst.src[0]) %>, <%- ref(inst.src[1]) %>, [<%- ref(inst.src[2]) %>, 0, 0]);
 <%              } else throw new Error("Invalid src dimensions");                          -%>
 <%          } else if (inst.src[2].dim==3) {                         -%>
 <%              if ((inst.src[0].dim==1) && (inst.src[1].dim==1)) {                         -%>
-    <%- outputName %> <== [<%- ref(inst.src[0]) %> * <%- ref(inst.src[1]) %> +  <%- ref(inst.src[2]) %>[0], <%- ref(inst.src[2]) %>[1], <%- ref(inst.src[2]) %>[2]];
+    signal <%- ref(inst.dest) %>[3] <== [<%- ref(inst.src[0]) %> * <%- ref(inst.src[1]) %> +  <%- ref(inst.src[2]) %>[0], <%- ref(inst.src[2]) %>[1], <%- ref(inst.src[2]) %>[2]];
 <%              } else {                                                                    -%>
-<%                  if (inst.src[0].dim==3 && inst.src[1].dim==3) {                      -%>
-    <%- outputName %> <== CMulAdd()(<%- ref(inst.src[0]) %>, <%- ref(inst.src[1]) %>, <%- ref(inst.src[2]) %>);
-<%                  } else if (inst.src[0].dim==3 && inst.src[1].dim==1) {                                       -%>
-    <%- outputName %> <== CMulAdd()(<%- ref(inst.src[0]) %>,[<%- ref(inst.src[1]) %>,0,0], <%- ref(inst.src[2]) %>);
-<%                  } else if (inst.src[0].dim==1 && inst.src[1].dim==3) {                                       -%>
-    <%- outputName %> <== CMulAdd()([<%- ref(inst.src[0]) %>,0,0], <%- ref(inst.src[1]) %>, <%- ref(inst.src[2]) %>);
-<%                  } else throw new Error("Invalid src dimensions");                          -%>
+<%                  let ina;
+                    let inb;
+                    let inc;
+                    if(inst.src[0].dim==3) {
+                        ina = `${ref(inst.src[0])}`;
+                    } else if(inst.src[0].dim==1) {
+                        ina = `[${ref(inst.src[0])}, 0, 0]`;
+                    } else throw new Error("Invalid src dimensions"); 
+                    if(inst.src[1].dim==3) {
+                        inb = `${ref(inst.src[1])}`;
+                    } else if(inst.src[1].dim==1) {
+                        inb = `[${ref(inst.src[1])}, 0, 0]`;
+                    } else throw new Error("Invalid src dimensions"); 
+                    if(inst.src[2].dim==3) {
+                        inc = `${ref(inst.src[2])}`;
+                    } else if(inst.src[2].dim==1) {
+                        inc = `[${ref(inst.src[2])}, 0, 0]`;
+                    } else throw new Error("Invalid src dimensions"); -%>
+    signal <%- ref(inst.dest) %>[3] <== CMulAdd()(<%- ina %>, <%- inb %>, <%- inc %>);
 <%              }                                                                           -%>
 <%          } else throw new Error("Invalid src dimensions");                              -%>
 <%      } else if (inst.op == "copy") {                                                 -%>
-<%          if (inst.src[0].dim==1 || inst.src[0].dim == 3) {                                                   -%>
-    <%- outputName %> <== <%- ref(inst.src[0]) %>;
+<%          if (inst.src[0].dim==1) {                                                   -%>
+    signal <%- ref(inst.dest) %> <== <%- ref(inst.src[0]) %>;
+<%          } else if (inst.src[0].dim==3) {                                            -%>
+    signal <%- ref(inst.dest) %>[3] <== <%- ref(inst.src[0]) %>;
 <%          } else throw new Error("Invalid src dimensions");                          -%>
 <%      } else throw new Error("Invalid op");                                           -%>
 <% }                                                                                    -%>
@@ -309,7 +317,9 @@ template parallel VerifyFRI(nBitsExt, prevStepBits, currStepBits, nextStepBits, 
     }
         
     // Perform an IFFT to obtain the coefficients of the polynomial given s_vals and evaluate it at ??????
-    signal evalPol[3] <== EvalPol(1<< step)(FFT(step, 3, 1)(s_vals_curr),[specialX[0] *  sx[currStepBits - 1], specialX[1] * sx[currStepBits - 1], specialX[2] *  sx[currStepBits - 1]]);
+    signal coefs[1 << step][3] <== FFT(step, 3, 1)(s_vals_curr);
+    signal evalXprime[3] <== [specialX[0] *  sx[currStepBits - 1], specialX[1] * sx[currStepBits - 1], specialX[2] *  sx[currStepBits - 1]];
+    signal evalPol[3] <== EvalPol(1 << step)(coefs, evalXprime);
 
     var keys_lowValues[nextStep];
     for(var i = 0; i < nextStep; i++) { keys_lowValues[i] = ys[i + nextStepBits]; } 


### PR DESCRIPTION
This PR adds a few fixes to the version 0.0.50:
- `merklehash.circom` is modified so that it contains two templates, one for only calculating the merkleHash and a second one that not only calculates the root but also verifies it.
- Adding back `iszero.circom` and `mux1.circom`, two templates that aren't used in pil-stark repo but used when calculating `recursive2.circom`
- Refactoring `unrollCode` for the stark verifiers