### PR TITLE
Audit fixes

### DIFF
--- a/circuits.gl/poseidon.circom
+++ b/circuits.gl/poseidon.circom
@@ -91,6 +91,8 @@ template custom CustPoseidon12() {
     signal output im[9][12];
     signal output out[12];
 
+    assert(key*(key - 1) == 0);
+
     var initialSt[12];
     
     // Order the inputs of the Poseidon hash according to the key bit.

--- a/circuits.gl/treeselector.circom
+++ b/circuits.gl/treeselector.circom
@@ -10,6 +10,11 @@ template custom TreeSelector8() {
     signal output out[3];
 
     var root[3];
+
+    assert(keys[0]*(keys[0] - 1) == 0);
+    assert(keys[1]*(keys[1] - 1) == 0);
+    assert(keys[2]*(keys[2] - 1) == 0);
+    
     if(keys[0] == 0 && keys[1] == 0 && keys[2] == 0) {
         root = values[0];
     } else if(keys[0] == 1 && keys[1] == 0 && keys[2] == 0) {

--- a/circuits.gl/treeselector4.circom
+++ b/circuits.gl/treeselector4.circom
@@ -10,6 +10,10 @@ template custom TreeSelector4() {
     signal output out[3];
 
     var root[3];
+
+    assert(keys[0]*(keys[0] - 1) == 0);
+    assert(keys[1]*(keys[1] - 1) == 0);
+    
     if(keys[0] == 0 && keys[1] == 0) {
         root = values[0];
     } else if(keys[0] == 1 && keys[1] == 0) {

--- a/src/compressor/compressor12.pil.ejs
+++ b/src/compressor/compressor12.pil.ejs
@@ -85,6 +85,9 @@ namespace Compressor(%N);
     pol custPoseidonInput6 = a[8] * (a[6] - a[2]) + a[2];
     pol custPoseidonInput7 = a[8] * (a[7] - a[3]) + a[3];
 
+    pol checkBinary = a[8] * (a[8] - 1);
+    POSEIDONCUSTFIRST * checkBinary = 0;
+
 <% for(let r = 0; r < 12; ++r) { -%>
     // If it is the first round of CustPoseidon, we need to set as input the previously calculated one. 
     // If it is the first round, we will add the corresponding constant and directly verify round 1.
@@ -95,7 +98,7 @@ namespace Compressor(%N);
 <%  } -%>
 <%  if (r > 0 && r < 11) { -%>
     // Calculate the 7th power of the <%- r %>th element
-    pol inpP<%- r %> = PARTIALROUND * s0_R<%- r - 1 %> + PARTIALROUND2 * s0_R<%- r + 11 - 1 %> + (POSEIDONM + POSEIDONFIRST + POSEIDONP + POSEIDONCUSTFIRST) * inp<%- r %>;
+    pol inpP<%- r %> = PARTIALROUND * s0_R<%- r - 1 %> + PARTIALROUND2 * s0_R<%- r + 11 - 1 %> + (POSEIDONM + POSEIDONP) * inp<%- r %>;
     pol a<%- r %>_2 = inpP<%- r %> * inpP<%- r %>;
     pol a<%- r %>_4 = a<%- r %>_2 * a<%- r %>_2;
     pol a<%- r %>_6 = a<%- r %>_4 * a<%- r %>_2;
@@ -174,7 +177,7 @@ namespace Compressor(%N);
 
 
 <% for(let i = 0; i < 12; ++i) { -%>
-    (POSEIDONM + POSEIDONFIRST + POSEIDONCUSTFIRST) * poseidonM<%- i %> = 0;
+    POSEIDONM * poseidonM<%- i %> = 0;
 <% } -%>
 
 <% for(let i = 0; i < 12; ++i) { -%>
@@ -340,6 +343,11 @@ namespace Compressor(%N);
     // Check that the plonk constraint stored in a[0], a[1], a[2] and a[3], a[4], a[5] are correct
     g012*TREESELECTOR4 = 0;
     g345*TREESELECTOR4 = 0;
+
+    pol checkBinaryKey1 = a[6]'*(1 - a[6]');
+    pol checkBinaryKey2 = a[7]'*(1 - a[7]');
+    TREESELECTOR4 * checkBinaryKey1 = 0;
+    TREESELECTOR4 * checkBinaryKey2 = 0;
 
     // Check connection equations of Plonk
 <% 

--- a/src/compressor/compressor12_setup.js
+++ b/src/compressor/compressor12_setup.js
@@ -157,7 +157,7 @@ module.exports = async function plonkSetup(F, r1cs, options) {
                 }
 
                 constPols.Compressor.GATE[r+i] = 0n;
-                constPols.Compressor.POSEIDONM[r+i] = i !== 0 && i !== 3 && i !== 4 && i !== 5 && i !== 10 ? 1n : 0n;
+                constPols.Compressor.POSEIDONM[r+i] = i !== 3 && i !== 4 && i !== 5 && i !== 10 ? 1n : 0n;
                 constPols.Compressor.POSEIDONP[r+i] = i === 3 ? 1n : 0n; // Round 3 -> Round 4
                 constPols.Compressor.POSEIDONCUSTFIRST[r+i] = 0n;
                 constPols.Compressor.POSEIDONFIRST[r+i] = i === 0 ? 1n : 0n; // Input -> Round 1
@@ -185,7 +185,7 @@ module.exports = async function plonkSetup(F, r1cs, options) {
                 }
 
                 constPols.Compressor.GATE[r+i] = 0n;
-                constPols.Compressor.POSEIDONM[r+i] = i !== 0 && i !== 3 && i !== 4 && i !== 5 && i !== 10 ? 1n : 0n;
+                constPols.Compressor.POSEIDONM[r+i] = i !== 3 && i !== 4 && i !== 5 && i !== 10 ? 1n : 0n;
                 constPols.Compressor.POSEIDONP[r+i] = i === 3 ? 1n : 0n; // Round 3 -> Round 4
                 constPols.Compressor.POSEIDONCUSTFIRST[r+i] = i === 0 ? 1n : 0n; // Input -> Round 1
                 constPols.Compressor.POSEIDONFIRST[r+i] = 0n;

--- a/src/compressor/compressor18.pil.ejs
+++ b/src/compressor/compressor18.pil.ejs
@@ -99,6 +99,9 @@ namespace Compressor(%N);
     pol custPoseidonInput6 = a[8] * (a[6] - a[2]) + a[2];
     pol custPoseidonInput7 = a[8] * (a[7] - a[3]) + a[3];
 
+    pol checkBinary = a[8] * (a[8] - 1);
+    POSEIDONCUSTFIRST * checkBinary = 0;
+
 <% for(let r = 0; r < 24; ++r) { -%>
 <% if(r === 12) { -%>
 <% for(let i = 0; i < 12; ++i) { -%>
@@ -193,7 +196,7 @@ namespace Compressor(%N);
 <% } -%>
 
 <% for(let i = 0; i < 12; ++i) { -%>
-    (POSEIDONM + POSEIDONAFTERPART + POSEIDONFIRST + POSEIDONCUSTFIRST) * poseidonM<%- i + 12 + 1 %> = 0;
+    POSEIDONM * poseidonM<%- i + 12 + 1 %> = 0;
 <% } -%>
 
 <% for(let i = 0; i < 12; i++)  { -%>
@@ -322,6 +325,11 @@ namespace Compressor(%N);
     // The values are stored from a[0], a[1], a[2] // a[3], a[4], a[5] // a[6], a[7], a[8] // a[9], a[10], a[11] 
     // The key is stored in [a[12], a[13]]
     // The output is stored in [a[14], a[15], a[16]]
+
+    pol checkBinaryKey1 = a[12]*(1 - a[12]);
+    pol checkBinaryKey2 = a[13]*(1 - a[13]);
+    TREESELECTOR4 * checkBinaryKey1 = 0;
+    TREESELECTOR4 * checkBinaryKey2 = 0;
 
     // keys1 will only be 1 if both a[12], a[13] are zero
     pol keys1 = (1 - a[12])*(1 - a[13]);

--- a/src/compressor/compressor18_setup.js
+++ b/src/compressor/compressor18_setup.js
@@ -178,7 +178,7 @@ module.exports = async function plonkSetup(F, r1cs, options) {
 
                 constPols.Compressor.GATE[r+i] = 0n;
                 constPols.Compressor.GATE2[r+i] = 0n;
-                constPols.Compressor.POSEIDONM[r+i] = i === 4 ? 1n : 0n; // Round 28 -> Output  
+                constPols.Compressor.POSEIDONM[r+i] = i === 4 || i === 0 || i === 3 ? 1n : 0n; // Round 28 -> Output  
                 constPols.Compressor.POSEIDONP[r+i] = i === 1 ? 1n : 0n; // Round 2 -> Round 4
                 constPols.Compressor.POSEIDONCUSTFIRST[r+i] = 0n;
                 constPols.Compressor.POSEIDONFIRST[r+i] = i === 0 ? 1n : 0n; // Inputs -> Round 2
@@ -226,7 +226,7 @@ module.exports = async function plonkSetup(F, r1cs, options) {
 
                 constPols.Compressor.GATE[r+i] = 0n;
                 constPols.Compressor.GATE2[r+i] = 0n;
-                constPols.Compressor.POSEIDONM[r+i] = i === 4 ? 1n : 0n; // Round 28 -> Output 
+                constPols.Compressor.POSEIDONM[r+i] = i === 4 || i === 0 || i === 3 ? 1n : 0n; // Round 28 -> Output 
                 constPols.Compressor.POSEIDONP[r+i] = i === 1 ? 1n : 0n; // Round 2 -> Round 4
                 constPols.Compressor.POSEIDONCUSTFIRST[r+i] = i === 0 ? 1n : 0n; // Inputs -> Round 2
                 constPols.Compressor.POSEIDONFIRST[r+i] = 0n;
@@ -460,7 +460,7 @@ module.exports = async function plonkSetup(F, r1cs, options) {
                 pr.nUsed++;
                 partialRows[k] = pr;
             } else if(pr.nUsed === 4) {
-                constPols.Compressor.GATE2[pr.row] = 0n;
+                constPols.Compressor.GATE2[pr.row] = 1n;
                 constPols.Compressor.C[12][pr.row] = c[3];
                 constPols.Compressor.C[13][pr.row] = c[4];
                 constPols.Compressor.C[14][pr.row] = c[5];

--- a/test/circuits/gl/circom/treeselector.test.circom
+++ b/test/circuits/gl/circom/treeselector.test.circom
@@ -1,5 +1,0 @@
-pragma circom 2.1.0;
-
-include "../../../../circuits.gl/treeselector.circom";
-
-component main = TreeSelector(5, 3);

--- a/test/circuits/gl/circom/treeselector.test.circom.ejs
+++ b/test/circuits/gl/circom/treeselector.test.circom.ejs
@@ -1,6 +1,6 @@
 pragma circom 2.1.0;
 pragma custom_templates;
 
-include "<%- dirName %>/../../circuits.gl/treeselector.circom";
+include "<%- dirName %>/../../../../circuits.gl/treeselector4.circom";
 
 component main = TreeSelector(<%- nBits %>, 3);

--- a/test/circuits/gl/treeselector.circuit.test.js
+++ b/test/circuits/gl/treeselector.circuit.test.js
@@ -1,0 +1,60 @@
+const chai = require("chai");
+const path = require("path");
+const tmp = require('temporary');
+const fs = require("fs");
+const ejs = require("ejs");
+const assert = chai.assert;
+
+const wasm_tester = require("circom_tester").wasm;
+
+function getBits(idx, nBits) {
+    res = [];
+    for (let i=0; i<nBits; i++) {
+        res[i] = (idx >> i)&1 ? 1n : 0n;
+    }
+    return res;
+}
+
+describe("TreeSelector Circuit Test", function () {
+    let circuit = [];
+
+    this.timeout(10000000);
+
+    before( async() => {
+        const template = await fs.promises.readFile(path.join(__dirname, "circom", "treeselector.test.circom.ejs"), "utf8");
+        
+        for(let i = 0; i <= 7; ++i) {
+            const content = ejs.render(template, {nBits: i, dirName:path.join(__dirname, "circom")});
+            const circuitFile = path.join(new tmp.Dir().path, "circuit.circom");
+            await fs.promises.writeFile(circuitFile, content);
+            circuit[i] = await wasm_tester(circuitFile, {O:1, prime: "goldilocks"});
+        }
+        
+    });
+
+    for (let i=0;i<=7;i++) {
+        it(`Should calculate tree selector with ${i} levels`, async () => {
+            const nBits = i;
+            const N = 1 << nBits;
+    
+            const values = [];
+            for (let j=0; j<N; j++) {
+                values[j] = [];
+                for (let k=0; k<3; k++) {
+                    values[j][k] = BigInt(k*100+j);
+                }
+            }
+    
+            for(let j = 0; j < N; ++j) {
+                const input={
+                    values: values,
+                    key: getBits(j, nBits)
+                };
+                
+                const w1 = await circuit[i].calculateWitness(input, true);
+                
+                await circuit[i].assertOut(w1, {out: values[j]});
+            }
+        });
+    };
+});


### PR DESCRIPTION
This PR adds a few fixes to the compressor circuits:
- For both, C18 and C12, a binary check is enforced for committed polynomial a[8] for CUSTPOSEIDON custom gate.
- For both, C18 and C12, binary checks are enforced for the keys of the treeSelector custom gate.
- In C18 setup, GATE2 is set to 1 in line 463 to make sure plonk constraints are verified
- In C18, PoseidonM is set to 1 when POSEIDONCUSTFIRST, POSEIDONAFTERPART or POSEIDONFIRST are 1 to simplify PIL logic.
- In C12, PoseidonM is set to 1 when POSEIDONCUSTFIRST or POSEIDONFIRST are 1 to simplify PIL logic.
- TreeSelector circom tests in JS are added.